### PR TITLE
Fix `Body.is~` failure

### DIFF
--- a/Tests/StubNetworkKitTests/Condition/BodyTests.swift
+++ b/Tests/StubNetworkKitTests/Condition/BodyTests.swift
@@ -19,11 +19,17 @@ final class BodyTests: XCTestCase {
     }
 
     func testIs() async throws {
+        #if os(watchOS)
+        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        try XCTSkipIf(true, "Unsupported platform for test.")
+        #endif
+
         let data = Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         stub(Body.is(data))
             .responseJson(["status": 200])
 
         var request = URLRequest(url: url)
+        request.httpMethod = "POST"
         request.httpBody = data
 
         let response = try await defaultStubSession.data(for: request)
@@ -32,10 +38,16 @@ final class BodyTests: XCTestCase {
     }
 
     func testIsJson() async throws {
+        #if os(watchOS)
+        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        try XCTSkipIf(true, "Unsupported platform for test.")
+        #endif
+
         stub(Body.isJson(["foo": "bar", "baz": 0]))
             .responseJson(["status": 200])
 
         var request = URLRequest(url: url)
+        request.httpMethod = "POST"
         request.httpBody = #"{"foo": "bar", "baz": 0}"#.data(using: .utf8)
 
         let response = try await defaultStubSession.data(for: request)
@@ -45,10 +57,16 @@ final class BodyTests: XCTestCase {
 
 
     func testIsForm() async throws {
+        #if os(watchOS)
+        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        try XCTSkipIf(true, "Unsupported platform for test.")
+        #endif
+
         stub(Body.isForm(["foo": "bar", "baz": "0", "qux": " "]))
             .responseJson(["status": 200])
 
         var request = URLRequest(url: url)
+        request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpBody = #"foo=bar&baz=0&qux=%20"#.data(using: .utf8)
 
@@ -63,12 +81,14 @@ final class BodyTests: XCTestCase {
         // FIXME: There is no way to get body stream with `URLSessionUploadTask` in Linux.
         try XCTSkipIf(true, "Unsupported platform for test.")
         #endif
+
         stub(Body.isMultipartForm([
             "foo": "bar".data(using: .utf8)!,
             "baz": Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
         ])).responseJson(["status": 200])
 
         var request = URLRequest(url: url)
+        request.httpMethod = "POST"
         let boundary = UUID().uuidString
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.httpBody = [

--- a/Tests/StubNetworkKitTests/Condition/BodyTests.swift
+++ b/Tests/StubNetworkKitTests/Condition/BodyTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import XCTest
+import StubNetworkKit
+
+final class BodyTests: XCTestCase {
+    private let url = URL(string: "https://localhost/foo/bar")!
+
+
+    override func setUpWithError() throws {
+        StubNetworking.option = .init(printDebugLog: true,
+                                      debugConditions: true)
+    }
+
+    override func tearDownWithError() throws {
+        clearStubs()
+    }
+
+    func testIs() async throws {
+        let data = Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        stub(Body.is(data))
+            .responseJson(["status": 200])
+
+        var request = URLRequest(url: url)
+        request.httpBody = data
+
+        let response = try await defaultStubSession.data(for: request)
+        XCTAssertEqual(#"{"status":200}"#, String(data: response.0, encoding: .utf8))
+        XCTAssertEqual((response.1 as? HTTPURLResponse)?.statusCode, 200)
+    }
+
+    func testIsJson() async throws {
+        stub(Body.isJson(["foo": "bar", "baz": 0]))
+            .responseJson(["status": 200])
+
+        var request = URLRequest(url: url)
+        request.httpBody = #"{"foo": "bar", "baz": 0}"#.data(using: .utf8)
+
+        let response = try await defaultStubSession.data(for: request)
+        XCTAssertEqual(#"{"status":200}"#, String(data: response.0, encoding: .utf8))
+        XCTAssertEqual((response.1 as? HTTPURLResponse)?.statusCode, 200)
+    }
+
+
+    func testIsForm() async throws {
+        stub(Body.isForm(["foo": "bar", "baz": "0", "qux": " "]))
+            .responseJson(["status": 200])
+
+        var request = URLRequest(url: url)
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = #"foo=bar&baz=0&qux=%20"#.data(using: .utf8)
+
+        let response = try await defaultStubSession.data(for: request)
+        XCTAssertEqual(#"{"status":200}"#, String(data: response.0, encoding: .utf8))
+        XCTAssertEqual((response.1 as? HTTPURLResponse)?.statusCode, 200)
+    }
+
+    func testIsMultipartForm() async throws {
+        #if os(watchOS) || os(Linux)
+        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        // FIXME: There is no way to get body stream with `URLSessionUploadTask` in Linux.
+        try XCTSkipIf(true, "Unsupported platform for test.")
+        #endif
+        stub(Body.isMultipartForm([
+            "foo": "bar".data(using: .utf8)!,
+            "baz": Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        ])).responseJson(["status": 200])
+
+        var request = URLRequest(url: url)
+        let boundary = UUID().uuidString
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = [
+            "--\(boundary)\r\n".data(using: .utf8)!,
+            "Content-Disposition: form-data; name=\"foo\"\r\n".data(using: .utf8)!,
+            "\r\n".data(using: .utf8)!,
+            "bar\r\n".data(using: .utf8)!,
+            "--\(boundary)\r\n".data(using: .utf8)!,
+            "Content-Disposition: form-data; name=\"baz\"\r\n".data(using: .utf8)!,
+            "\r\n".data(using: .utf8)!,
+            Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            "\r\n".data(using: .utf8)!,
+            "--\(boundary)--\r\n".data(using: .utf8)!,
+        ].reduce(Data(), +)
+
+        let response = try await defaultStubSession.data(for: request)
+        XCTAssertEqual(#"{"status":200}"#, String(data: response.0, encoding: .utf8))
+        XCTAssertEqual((response.1 as? HTTPURLResponse)?.statusCode, 200)
+    }
+}

--- a/Tests/StubNetworkKitTests/Sample/APIKitSampleTests.swift
+++ b/Tests/StubNetworkKitTests/Sample/APIKitSampleTests.swift
@@ -7,6 +7,9 @@ final class APIKitSampleTests: XCTestCase {
     private var client: APIKitSample!
 
     override func setUpWithError() throws {
+        StubNetworking.option = .init(printDebugLog: true,
+                                      debugConditions: true)
+
         let config = URLSessionConfiguration.ephemeral
         registerStub(to: config)
         let adapter = URLSessionAdapter(configuration: config)
@@ -22,11 +25,39 @@ final class APIKitSampleTests: XCTestCase {
             Scheme.is("https")
             Host.is("foo.bar")
             Path.is("/baz/qux")
+            Method.isGet()
         }.responseData(withFilePath: "Fixtures/sample",
                        extension: "json",
                        in: .module)
 
         let result = try await client.fetch()
+        XCTAssertEqual(result.foo, "hoge")
+        XCTAssertEqual(result.bar, 42)
+        XCTAssertTrue(result.baz)
+        let child = result.qux
+        XCTAssertEqual(child.quux, "fuga")
+        XCTAssertEqual(child.corge, 3.14, accuracy: 0.01)
+        XCTAssertFalse(child.grault)
+        XCTAssertEqual(child.garply, ["spam", "ham", "eggs"])
+    }
+
+    func testPost() async throws {
+        #if os(watchOS)
+        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        try XCTSkipIf(true, "Unsupported platform for test.")
+        #endif
+
+        stub {
+            Scheme.is("https")
+            Host.is("foo.bar")
+            Path.is("/baz/qux")
+            Method.isPost()
+            Body.isJson(["hoge": "fuga"])
+        }.responseData(withFilePath: "Fixtures/sample",
+                       extension: "json",
+                       in: .module)
+
+        let result = try await client.post()
         XCTAssertEqual(result.foo, "hoge")
         XCTAssertEqual(result.bar, 42)
         XCTAssertTrue(result.baz)
@@ -48,6 +79,7 @@ final class APIKitSampleTests: XCTestCase {
             Scheme.is("https")
             Host.is("foo.bar")
             Path.is("/baz/qux")
+            Method.isPost()
             Body.isMultipartForm([
                 "hoge": "fuga".data(using: .utf8)!,
                 "piyo": "hogera".data(using: .utf8)!,
@@ -78,7 +110,11 @@ private final class APIKitSample {
 
 extension APIKitSample {
     func fetch() async throws -> SampleEntity {
-        try await session.response(for: SampleRequest())
+        try await session.response(for: SampleGetRequest())
+    }
+
+    func post() async throws -> SampleEntity {
+        try await session.response(for: SamplePostRequest())
     }
 
     func form() async throws -> SampleEntity {
@@ -86,12 +122,12 @@ extension APIKitSample {
     }
 }
 
-struct SampleRequest: Request {
-    typealias Response = SampleEntity
+private protocol SampleRequest: Request where Response == SampleEntity {
+}
 
+extension SampleRequest {
     var baseURL: URL { URL(string: "https://foo.bar")! }
     var path: String { "/baz/qux" }
-    var method: HTTPMethod { .get }
 
     func response(from object: Any, urlResponse: HTTPURLResponse) throws -> SampleEntity {
         let data = try (object as? Data) ?? (try JSONSerialization.data(withJSONObject: object, options: []))
@@ -100,23 +136,26 @@ struct SampleRequest: Request {
     }
 }
 
-struct SampleFormRequest: Request {
-    typealias Response = SampleEntity
+private struct SampleGetRequest: SampleRequest {
+    var method: HTTPMethod { .get }
+}
 
-    var baseURL: URL { URL(string: "https://foo.bar")! }
-    var path: String { "/baz/qux" }
+private struct SamplePostRequest: SampleRequest {
     var method: HTTPMethod { .post }
+
+    var bodyParameters: BodyParameters? {
+        ["hoge": "fuga"] as JSONBodyParameters
+    }
+}
+
+private struct SampleFormRequest: SampleRequest {
+    var method: HTTPMethod { .post }
+
     var bodyParameters: BodyParameters? {
         MultipartFormDataBodyParameters(parts: [
             .init(data: "fuga".data(using: .utf8)!, name: "hoge"),
             .init(data: "hogera".data(using: .utf8)!, name: "piyo")
         ])
-    }
-
-    func response(from object: Any, urlResponse: HTTPURLResponse) throws -> SampleEntity {
-        let data = try (object as? Data) ?? (try JSONSerialization.data(withJSONObject: object, options: []))
-        return try JSONDecoder()
-            .decode(Response.self, from: data)
     }
 }
 #endif

--- a/Tests/StubNetworkKitTests/Sample/AlamofireSampleTests.swift
+++ b/Tests/StubNetworkKitTests/Sample/AlamofireSampleTests.swift
@@ -7,6 +7,9 @@ final class AlamofireSampleTests: XCTestCase {
     private var client: AlamofireSample!
 
     override func setUpWithError() throws {
+        StubNetworking.option = .init(printDebugLog: true,
+                                      debugConditions: true)
+
         let config = URLSessionConfiguration.af.ephemeral
         registerStub(to: config)
         client = AlamofireSample(Session(configuration: config))
@@ -21,11 +24,38 @@ final class AlamofireSampleTests: XCTestCase {
             Scheme.is("https")
             Host.is("foo.bar")
             Path.is("/baz")
+            Method.isGet()
         }.responseData(withFilePath: "Fixtures/sample",
                        extension: "json",
                        in: .module)
 
         let result = try await client.fetch()
+        XCTAssertEqual(result.foo, "hoge")
+        XCTAssertEqual(result.bar, 42)
+        XCTAssertTrue(result.baz)
+        let child = result.qux
+        XCTAssertEqual(child.quux, "fuga")
+        XCTAssertEqual(child.corge, 3.14, accuracy: 0.01)
+        XCTAssertFalse(child.grault)
+        XCTAssertEqual(child.garply, ["spam", "ham", "eggs"])
+    }
+
+    func testPost() async throws {
+        #if os(watchOS)
+        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        try XCTSkipIf(true, "Unsupported platform for test.")
+        #endif
+
+        stub {
+            Scheme.is("https")
+            Host.is("foo.bar")
+            Path.is("/baz")
+            Method.isPost()
+        }.responseData(withFilePath: "Fixtures/sample",
+                       extension: "json",
+                       in: .module)
+
+        let result = try await client.post()
         XCTAssertEqual(result.foo, "hoge")
         XCTAssertEqual(result.bar, 42)
         XCTAssertTrue(result.baz)
@@ -47,6 +77,7 @@ final class AlamofireSampleTests: XCTestCase {
             Scheme.is("https")
             Host.is("foo.bar")
             Path.is("/baz")
+            Method.isPost()
             Body.isMultipartForm([
                 "hoge": "fuga".data(using: .utf8)!,
                 "piyo": "hogera".data(using: .utf8)!,
@@ -77,8 +108,15 @@ private final class AlamofireSample {
 
 extension AlamofireSample {
     func fetch() async throws -> SampleEntity {
-        let url = URL(string: "https://foo.bar/baz")!
-        return try await session.request(url)
+        try await session.request(URL(string: "https://foo.bar/baz")!)
+            .serializingDecodable(SampleEntity.self)
+            .response
+            .result
+            .get()
+    }
+
+    func post() async throws -> SampleEntity {
+        try await session.request(URLRequest(url: URL(string: "https://foo.bar/baz")!, method: .post))
             .serializingDecodable(SampleEntity.self)
             .response
             .result
@@ -91,7 +129,7 @@ extension AlamofireSample {
                 formData.append("fuga".data(using: .utf8)!, withName: "hoge")
                 formData.append("hogera".data(using: .utf8)!, withName: "piyo")
             },
-            with: URLRequest(url: URL(string: "https://foo.bar/baz")!)
+            with: URLRequest(url: URL(string: "https://foo.bar/baz")!, method: .post)
         )
         .serializingDecodable(SampleEntity.self)
         .response

--- a/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
+++ b/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
@@ -30,12 +30,18 @@ final class StubNetworkKitTests: XCTestCase {
 
     /// Example function for basic implementation
     func testDefaultStubSession_basic_post() async throws {
+        #if os(watchOS)
+        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        try XCTSkipIf(true, "Unsupported platform for test.")
+        #endif
+
         let url = URL(string: "foo://bar/baz")!
 
-        stub(Scheme.is("foo") && Host.is("bar") && Path.is("/baz") && Body.isJson(["key": "world"]))
+        stub(Scheme.is("foo") && Host.is("bar") && Path.is("/baz") && Method.isPost() && Body.isJson(["key": "world"]))
             .responseData("Hello world!".data(using: .utf8)!)
 
         var request = URLRequest(url: url)
+        request.httpMethod = "POST"
         request.httpBody = #"{"key": "world"}"#.data(using: .utf8)
 
         let (data, response) = try await defaultStubSession.data(for: request)
@@ -77,16 +83,23 @@ final class StubNetworkKitTests: XCTestCase {
 
     /// Example function for using Result Builder implementation
     func testDefaultStubSession_resultBuilder_post() async throws {
+        #if os(watchOS)
+        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        try XCTSkipIf(true, "Unsupported platform for test.")
+        #endif
+
         let url = URL(string: "foo://bar/baz")!
 
         stub {
             Scheme.is("foo")
             Host.is("bar")
             Path.is("/baz")
+            Method.isPost()
             Body.isJson(["key": "world"])
         }.responseData("Hello world!".data(using: .utf8)!)
 
         var request = URLRequest(url: url)
+        request.httpMethod = "POST"
         request.httpBody = #"{"key": "world"}"#.data(using: .utf8)
 
         let (data, response) = try await defaultStubSession.data(for: request)

--- a/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
+++ b/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
@@ -29,6 +29,21 @@ final class StubNetworkKitTests: XCTestCase {
     }
 
     /// Example function for basic implementation
+    func testDefaultStubSession_basic_post() async throws {
+        let url = URL(string: "foo://bar/baz")!
+
+        stub(Scheme.is("foo") && Host.is("bar") && Path.is("/baz") && Body.isJson(["key": "world"]))
+            .responseData("Hello world!".data(using: .utf8)!)
+
+        var request = URLRequest(url: url)
+        request.httpBody = #"{"key": "world"}"#.data(using: .utf8)
+
+        let (data, response) = try await defaultStubSession.data(for: request)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "Hello world!")
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+    }
+
+    /// Example function for basic implementation
     func testDefaultStubSession_basic_customResponse() async throws {
         let url = URL(string: "foo://bar/baz?q=1")!
 
@@ -59,6 +74,26 @@ final class StubNetworkKitTests: XCTestCase {
         XCTAssertEqual(String(data: data, encoding: .utf8), "Hello world!")
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
     }
+
+    /// Example function for using Result Builder implementation
+    func testDefaultStubSession_resultBuilder_post() async throws {
+        let url = URL(string: "foo://bar/baz")!
+
+        stub {
+            Scheme.is("foo")
+            Host.is("bar")
+            Path.is("/baz")
+            Body.isJson(["key": "world"])
+        }.responseData("Hello world!".data(using: .utf8)!)
+
+        var request = URLRequest(url: url)
+        request.httpBody = #"{"key": "world"}"#.data(using: .utf8)
+
+        let (data, response) = try await defaultStubSession.data(for: request)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "Hello world!")
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+    }
+
 
     /// Example function for using Result Builder implementation
     func testDefaultStubSession_resultBuilder_customResponse() async throws {

--- a/Tests/StubNetworkKitTests/Util/URLSession+Concurrency+LinuxSupport.swift
+++ b/Tests/StubNetworkKitTests/Util/URLSession+Concurrency+LinuxSupport.swift
@@ -5,9 +5,27 @@ import FoundationNetworking
 
 #if !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)) && compiler(>=5.6) && canImport(_Concurrency)
 extension URLSession {
-    func data(from url: URL, delegate: URLSessionTaskDelegate? = nil) async throws -> (Data, URLResponse) {
+    func data(
+        from url: URL,
+        delegate: URLSessionTaskDelegate? = nil
+    ) async throws -> (Data, URLResponse) {
         try await withCheckedThrowingContinuation { cont in
             dataTask(with: url) { data, response, error in
+                if let error = error {
+                    cont.resume(throwing: error)
+                    return
+                }
+                cont.resume(returning: (data!, response!))
+            }.resume()
+        }
+    }
+
+    func data(
+        for request: URLRequest,
+        delegate: (URLSessionTaskDelegate)? = nil
+    ) async throws -> (Data, URLResponse) {
+        try await withCheckedThrowingContinuation { cont in
+            dataTask(with: request) { data, response, error in
                 if let error = error {
                     cont.resume(throwing: error)
                     return


### PR DESCRIPTION
Resolves #23
