### PR TITLE
Update watchOS supporting

### DIFF
--- a/Sources/StubNetworkKit/Condition/Body.swift
+++ b/Sources/StubNetworkKit/Condition/Body.swift
@@ -6,6 +6,7 @@ import MultipartFormDataParser
 
 public enum Body: Equatable {}
 
+@available(watchOS, unavailable, message: "Intercepting POST request is not available in watchOS")
 public extension Body {
     static func `is`(_ body: Data,
                      file: StaticString = #file,
@@ -15,6 +16,7 @@ public extension Body {
 }
 
 // MARK: - JSON
+@available(watchOS, unavailable, message: "Intercepting POST request is not available in watchOS")
 public extension Body {
     static func isJson(_ jsonObject: [AnyHashable: Any],
                        file: StaticString = #file,
@@ -30,6 +32,7 @@ public extension Body {
 }
 
 // MARK: - Form
+@available(watchOS, unavailable, message: "Intercepting POST request is not available in watchOS")
 public extension Body {
     static func isForm(_ queryItems: [URLQueryItem], file: StaticString = #file, line: UInt = #line) -> some StubCondition {
         _Body.isForm(queryItems, file: file, line: line)

--- a/Sources/StubNetworkKit/Condition/Method.swift
+++ b/Sources/StubNetworkKit/Condition/Method.swift
@@ -30,18 +30,27 @@ public extension Method {
     static func isGet(file: StaticString = #file, line: UInt = #line) -> some StubCondition {
         _Method.isGet(file: file, line: line)
     }
+
+    @available(watchOS, unavailable, message: "Intercepting POST request is not available in watchOS")
     static func isPost(file: StaticString = #file, line: UInt = #line) -> some StubCondition {
         _Method.isPost(file: file, line: line)
     }
+
+    @available(watchOS, unavailable, message: "Intercepting PUT request is not available in watchOS")
     static func isPut(file: StaticString = #file, line: UInt = #line) -> some StubCondition {
         _Method.isPut(file: file, line: line)
     }
+
+    @available(watchOS, unavailable, message: "Intercepting PATCH request is not available in watchOS")
     static func isPatch(file: StaticString = #file, line: UInt = #line) -> some StubCondition {
         _Method.isPatch(file: file, line: line)
     }
+
+    @available(watchOS, unavailable, message: "Intercepting DELETE request is not available in watchOS")
     static func isDelete(file: StaticString = #file, line: UInt = #line) -> some StubCondition {
         _Method.isDelete(file: file, line: line)
     }
+
     static func isHead(file: StaticString = #file, line: UInt = #line) -> some StubCondition {
         _Method.isHead(file: file, line: line)
     }

--- a/Sources/StubNetworkKit/Stub.swift
+++ b/Sources/StubNetworkKit/Stub.swift
@@ -267,6 +267,7 @@ public extension Stub {
 }
 
 // MARK: Body
+@available(watchOS, unavailable, message: "Intercepting POST request is not available in watchOS")
 public extension Stub {
     @discardableResult
     func body(_ body: Data,

--- a/Sources/StubNetworkKit/StubNetworking.swift
+++ b/Sources/StubNetworkKit/StubNetworking.swift
@@ -39,14 +39,14 @@ public func registerStub(to configuration: URLSessionConfiguration) {
     configuration.protocolClasses = [StubURLProtocol.self]
 }
 
-// FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+// NOTE: Testing on watchOS(~8), `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
 /// Handle all requests via `URLSession.shared`
-@available(watchOS, unavailable, message: "Intercepting `URLSession.shared` is unavailable in watchOS.")
+@available(watchOS, introduced: 9, message: "Intercepting `URLSession.shared` is unavailable in watchOS(~8).")
 public func registerStubForSharedSession() {
     assert(URLProtocol.registerClass(StubURLProtocol.self))
 }
 
-@available(watchOS, unavailable, message: "Intercepting `URLSession.shared` is unavailable in watchOS.")
+@available(watchOS, introduced: 9, message: "Intercepting `URLSession.shared` is unavailable in watchOS(~8).")
 public func unregisterStubForSharedSession() {
     URLProtocol.unregisterClass(StubURLProtocol.self)
 }

--- a/Tests/StubNetworkKitTests/Condition/BodyTests.swift
+++ b/Tests/StubNetworkKitTests/Condition/BodyTests.swift
@@ -5,6 +5,7 @@ import FoundationNetworking
 import XCTest
 import StubNetworkKit
 
+#if !os(watchOS)
 @available(watchOS, unavailable)
 final class BodyTests: XCTestCase {
     private let url = URL(string: "https://localhost/foo/bar")!
@@ -93,3 +94,4 @@ final class BodyTests: XCTestCase {
         XCTAssertEqual((response.1 as? HTTPURLResponse)?.statusCode, 200)
     }
 }
+#endif

--- a/Tests/StubNetworkKitTests/Condition/BodyTests.swift
+++ b/Tests/StubNetworkKitTests/Condition/BodyTests.swift
@@ -5,9 +5,9 @@ import FoundationNetworking
 import XCTest
 import StubNetworkKit
 
+@available(watchOS, unavailable)
 final class BodyTests: XCTestCase {
     private let url = URL(string: "https://localhost/foo/bar")!
-
 
     override func setUpWithError() throws {
         StubNetworking.option = .init(printDebugLog: true,
@@ -19,11 +19,6 @@ final class BodyTests: XCTestCase {
     }
 
     func testIs() async throws {
-        #if os(watchOS)
-        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
-        try XCTSkipIf(true, "Unsupported platform for test.")
-        #endif
-
         let data = Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         stub(Body.is(data))
             .responseJson(["status": 200])
@@ -38,11 +33,6 @@ final class BodyTests: XCTestCase {
     }
 
     func testIsJson() async throws {
-        #if os(watchOS)
-        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
-        try XCTSkipIf(true, "Unsupported platform for test.")
-        #endif
-
         stub(Body.isJson(["foo": "bar", "baz": 0]))
             .responseJson(["status": 200])
 
@@ -57,11 +47,6 @@ final class BodyTests: XCTestCase {
 
 
     func testIsForm() async throws {
-        #if os(watchOS)
-        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
-        try XCTSkipIf(true, "Unsupported platform for test.")
-        #endif
-
         stub(Body.isForm(["foo": "bar", "baz": "0", "qux": " "]))
             .responseJson(["status": 200])
 
@@ -76,8 +61,7 @@ final class BodyTests: XCTestCase {
     }
 
     func testIsMultipartForm() async throws {
-        #if os(watchOS) || os(Linux)
-        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        #if os(Linux)
         // FIXME: There is no way to get body stream with `URLSessionUploadTask` in Linux.
         try XCTSkipIf(true, "Unsupported platform for test.")
         #endif

--- a/Tests/StubNetworkKitTests/Sample/APIKitSampleTests.swift
+++ b/Tests/StubNetworkKitTests/Sample/APIKitSampleTests.swift
@@ -41,6 +41,7 @@ final class APIKitSampleTests: XCTestCase {
         XCTAssertEqual(child.garply, ["spam", "ham", "eggs"])
     }
 
+    #if !os(watchOS)
     @available(watchOS, unavailable)
     func testPost() async throws {
         stub {
@@ -94,6 +95,7 @@ final class APIKitSampleTests: XCTestCase {
         XCTAssertFalse(child.grault)
         XCTAssertEqual(child.garply, ["spam", "ham", "eggs"])
     }
+    #endif
 }
 
 private final class APIKitSample {

--- a/Tests/StubNetworkKitTests/Sample/APIKitSampleTests.swift
+++ b/Tests/StubNetworkKitTests/Sample/APIKitSampleTests.swift
@@ -41,12 +41,8 @@ final class APIKitSampleTests: XCTestCase {
         XCTAssertEqual(child.garply, ["spam", "ham", "eggs"])
     }
 
+    @available(watchOS, unavailable)
     func testPost() async throws {
-        #if os(watchOS)
-        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
-        try XCTSkipIf(true, "Unsupported platform for test.")
-        #endif
-
         stub {
             Scheme.is("https")
             Host.is("foo.bar")
@@ -68,9 +64,9 @@ final class APIKitSampleTests: XCTestCase {
         XCTAssertEqual(child.garply, ["spam", "ham", "eggs"])
     }
 
+    @available(watchOS, unavailable)
     func testMultipartForm() async throws {
-        #if os(watchOS) || os(Linux)
-        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        #if os(Linux)
         // FIXME: There is no way to get body stream with `URLSessionUploadTask` in Linux.
         try XCTSkipIf(true, "Unsupported platform for test.")
         #endif

--- a/Tests/StubNetworkKitTests/Sample/AlamofireSampleTests.swift
+++ b/Tests/StubNetworkKitTests/Sample/AlamofireSampleTests.swift
@@ -40,6 +40,7 @@ final class AlamofireSampleTests: XCTestCase {
         XCTAssertEqual(child.garply, ["spam", "ham", "eggs"])
     }
 
+    #if !os(watchOS)
     @available(watchOS, unavailable)
     func testPost() async throws {
         stub {
@@ -92,6 +93,7 @@ final class AlamofireSampleTests: XCTestCase {
         XCTAssertFalse(child.grault)
         XCTAssertEqual(child.garply, ["spam", "ham", "eggs"])
     }
+    #endif
 }
 
 private final class AlamofireSample {

--- a/Tests/StubNetworkKitTests/Sample/AlamofireSampleTests.swift
+++ b/Tests/StubNetworkKitTests/Sample/AlamofireSampleTests.swift
@@ -40,12 +40,8 @@ final class AlamofireSampleTests: XCTestCase {
         XCTAssertEqual(child.garply, ["spam", "ham", "eggs"])
     }
 
+    @available(watchOS, unavailable)
     func testPost() async throws {
-        #if os(watchOS)
-        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
-        try XCTSkipIf(true, "Unsupported platform for test.")
-        #endif
-
         stub {
             Scheme.is("https")
             Host.is("foo.bar")
@@ -66,9 +62,9 @@ final class AlamofireSampleTests: XCTestCase {
         XCTAssertEqual(child.garply, ["spam", "ham", "eggs"])
     }
 
+    @available(watchOS, unavailable)
     func testMultipartForm() async throws {
-        #if os(watchOS) || os(Linux)
-        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
+        #if os(Linux)
         // FIXME: There is no way to get body stream with `URLSessionUploadTask` in Linux.
         try XCTSkipIf(true, "Unsupported platform for test.")
         #endif

--- a/Tests/StubNetworkKitTests/StubCondition+ResultBuilderTests.swift
+++ b/Tests/StubNetworkKitTests/StubCondition+ResultBuilderTests.swift
@@ -6,6 +6,7 @@ import StubNetworkKit
 import SwiftParamTest
 
 final class StubCondition_ResultBuilderTests: XCTestCase {
+    @available(watchOS, unavailable)
     func testBuild() throws {
         var req = URLRequest(url: .init(string: "https://foo.bar/baz?q=1&flag")!)
         req.httpMethod = "POST"
@@ -44,12 +45,11 @@ final class StubCondition_ResultBuilderTests: XCTestCase {
         XCTAssertTrue(condition.matcher(req))
     }
 
+    @available(watchOS, unavailable)
     func testBuildEither() throws {
-
         func test(_ method: String) -> Bool {
             var request = URLRequest(url: .init(string: "https://foo.bar/baz?q=1&flag")!)
             request.httpMethod = method
-
             let condition = stubCondition {
                 Scheme.is("https")
                 Host.is("foo.bar")

--- a/Tests/StubNetworkKitTests/StubMatcherTests.swift
+++ b/Tests/StubNetworkKitTests/StubMatcherTests.swift
@@ -28,6 +28,7 @@ final class StubMatcherTests: XCTestCase {
             expect(createRequest(method: "DELETE") ==> false)
             expect(createRequest(method: "HEAD") ==> false)
         }
+        #if !os(watchOS)
         assert(to: Method.isPost().matcher) {
             expect(createRequest(method: "GET") ==> false)
             expect(createRequest(method: "POST") ==> true)
@@ -60,6 +61,7 @@ final class StubMatcherTests: XCTestCase {
             expect(createRequest(method: "DELETE") ==> true)
             expect(createRequest(method: "HEAD") ==> false)
         }
+        #endif
         assert(to: Method.isHead().matcher) {
             expect(createRequest(method: "GET") ==> false)
             expect(createRequest(method: "POST") ==> false)
@@ -322,6 +324,7 @@ final class StubMatcherTests: XCTestCase {
         }
     }
 
+    @available(watchOS, unavailable)
     func testBodyIs() throws {
         func request(_ body: String?) -> URLRequest {
             var req = URLRequest(url: URL(string: "foo://bar")!)
@@ -338,6 +341,7 @@ final class StubMatcherTests: XCTestCase {
         }
     }
 
+    @available(watchOS, unavailable)
     func testBodyIsJsonObject() throws {
         func request(_ jsonString: String) -> URLRequest {
             var req = URLRequest(url: URL(string: "foo://bar")!)
@@ -363,6 +367,7 @@ final class StubMatcherTests: XCTestCase {
         }
     }
 
+    @available(watchOS, unavailable)
     func testBodyIsJsonArray() throws {
         func request(_ jsonString: String) -> URLRequest {
             var req = URLRequest(url: URL(string: "foo://bar")!)
@@ -386,6 +391,7 @@ final class StubMatcherTests: XCTestCase {
         }
     }
 
+    @available(watchOS, unavailable)
     func testBodyIsForm() throws {
         func request(_ formBody: String, addHeader: Bool = true) -> URLRequest {
             var req = URLRequest(url: URL(string: "foo://bar")!)

--- a/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
+++ b/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
@@ -28,12 +28,8 @@ final class StubNetworkKitTests: XCTestCase {
     }
 
     /// Example function for basic implementation
+    @available(watchOS, unavailable)
     func testDefaultStubSession_basic_post() async throws {
-        #if os(watchOS)
-        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
-        try XCTSkipIf(true, "Unsupported platform for test.")
-        #endif
-
         let url = URL(string: "foo://bar/baz")!
 
         stub(Scheme.is("foo") && Host.is("bar") && Path.is("/baz") && Method.isPost() && Body.isJson(["key": "world"]))
@@ -81,12 +77,8 @@ final class StubNetworkKitTests: XCTestCase {
     }
 
     /// Example function for using Result Builder implementation
+    @available(watchOS, unavailable)
     func testDefaultStubSession_resultBuilder_post() async throws {
-        #if os(watchOS)
-        // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
-        try XCTSkipIf(true, "Unsupported platform for test.")
-        #endif
-
         let url = URL(string: "foo://bar/baz")!
 
         stub {

--- a/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
+++ b/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
@@ -27,6 +27,7 @@ final class StubNetworkKitTests: XCTestCase {
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
     }
 
+    #if !os(watchOS)
     /// Example function for basic implementation
     @available(watchOS, unavailable)
     func testDefaultStubSession_basic_post() async throws {
@@ -43,6 +44,7 @@ final class StubNetworkKitTests: XCTestCase {
         XCTAssertEqual(String(data: data, encoding: .utf8), "Hello world!")
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
     }
+    #endif
 
     /// Example function for basic implementation
     func testDefaultStubSession_basic_customResponse() async throws {
@@ -76,6 +78,7 @@ final class StubNetworkKitTests: XCTestCase {
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
     }
 
+    #if !os(watchOS)
     /// Example function for using Result Builder implementation
     @available(watchOS, unavailable)
     func testDefaultStubSession_resultBuilder_post() async throws {
@@ -97,7 +100,7 @@ final class StubNetworkKitTests: XCTestCase {
         XCTAssertEqual(String(data: data, encoding: .utf8), "Hello world!")
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
     }
-
+    #endif
 
     /// Example function for using Result Builder implementation
     func testDefaultStubSession_resultBuilder_customResponse() async throws {

--- a/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
+++ b/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
@@ -224,9 +224,8 @@ final class StubNetworkKitTests: XCTestCase {
         )
     }
 
-    // FIXME: When testing on watchOS, `StubURLProtocol.startLoading` isn't called, although `canInit` has been called.
-    #if !os(watchOS)
     /// Example function for intercepting `URLSession.shared` requests
+    @available(watchOS 9, *)
     func testSharedSession() async throws {
         registerStubForSharedSession()
         defer { unregisterStubForSharedSession() }
@@ -240,7 +239,6 @@ final class StubNetworkKitTests: XCTestCase {
         XCTAssertEqual(String(data: data, encoding: .utf8), "Hello world!")
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
     }
-    #endif
 }
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)

--- a/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
+++ b/Tests/StubNetworkKitTests/StubNetworkKitTests.swift
@@ -5,7 +5,6 @@ import FoundationNetworking
 import XCTest
 import StubNetworkKit
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 final class StubNetworkKitTests: XCTestCase {
     override func setUp() {
         StubNetworking.option = .init(printDebugLog: true,
@@ -241,7 +240,6 @@ final class StubNetworkKitTests: XCTestCase {
     }
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 private extension StubNetworkKitTests {
     struct Sample: Decodable, Equatable {
         var foo: String

--- a/Tests/StubNetworkKitTests/StubTests.swift
+++ b/Tests/StubNetworkKitTests/StubTests.swift
@@ -44,6 +44,7 @@ final class StubTests: XCTestCase {
             expect(URL(string: "https://foo.bar/baz")! ==> false)
         }
 
+        #if !os(watchOS)
         let condition2 = stub()
             .scheme("https")
             .host("foo.bar")
@@ -61,6 +62,6 @@ final class StubTests: XCTestCase {
             expect(URL(string: "https://foo.bar/baz?q=1&empty=&flag")! ==> false)
             expect(URL(string: "https://foo.bar/baz")! ==> false)
         }
-
+        #endif
     }
 }


### PR DESCRIPTION
`StubURLProtocol.startLoading` has been called since watchOS 9.